### PR TITLE
Parse start/end only if Index of type Datetime

### DIFF
--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6663,7 +6663,8 @@ class Index(IndexOpsMixin, PandasObject):
 
         # GH 16785: If start and end happen to be date strings with UTC offsets
         # attempt to parse and check that the offsets are the same
-        if isinstance(start, (str, datetime)) and isinstance(end, (str, datetime)):
+        if (self.is_type_compatible("datetime") and
+            isinstance(start, (str, datetime)) and isinstance(end, (str, datetime)):
             try:
                 ts_start = Timestamp(start)
                 ts_end = Timestamp(end)

--- a/pandas/core/indexes/base.py
+++ b/pandas/core/indexes/base.py
@@ -6664,7 +6664,7 @@ class Index(IndexOpsMixin, PandasObject):
         # GH 16785: If start and end happen to be date strings with UTC offsets
         # attempt to parse and check that the offsets are the same
         if (self.is_type_compatible("datetime") and
-            isinstance(start, (str, datetime)) and isinstance(end, (str, datetime)):
+            isinstance(start, (str, datetime)) and isinstance(end, (str, datetime))):
             try:
                 ts_start = Timestamp(start)
                 ts_end = Timestamp(end)


### PR DESCRIPTION
Many of the existing tests are already failing if compiling with [sanitizers](https://github.com/google/sanitizers):
> runtime error: signed integer overflow: 253370764800000000 * 1000 cannot be represented in type 'long'

One pretty common use case when this happens, is when using a `TimedeltaIndex`, and passing a string representing a time delta to index it (e.g. '12 hours'). The existing code still tries to perform a Datetime specific check which leads to a cast attempt `Timestamp('12 hours')`, which is normal conditions is caught as a python exception by the `try: except:` and ignored (hence, the casting is ignored). However, it still leads to an unnecessary overflow happening in between.

As far as I can tell, there is not reason to run this Datetime specific check in the first place, unless we are dealing with an indexer for Datetime objects, hence the proposed change.